### PR TITLE
add method to approve privacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,3 +67,5 @@ main()
   - `metamask.confirmTransaction([{ gas, gasLimit }])`: commands MetaMask to submit a transaction. For this to work MetaMask has to be in a transaction confirmation state (basically promting the user to submit/reject a transaction). You can (optionally) pass an object with `gas` and/or `gasLimit`, by default they are `20` and `50000` respectively.
 
   - `metamask.sign()`: commands MetaMask to sign a message. For this to work MetaMask must be in a sign confirmation state.
+  
+  - `metamask.approve()`: enables the app to connect to MetaMask account in privacy mode

--- a/index.js
+++ b/index.js
@@ -233,7 +233,20 @@ module.exports = {
         await button.click()
 
         await waitForUnlockedScreen(metamaskPage);
-      }
+      },
+
+      approve: async () => {
+        await metamaskPage.bringToFront()
+
+        const confirmButtonSelector = 'button.button.btn-confirm.btn--large.page-container__footer-button'
+
+        await metamaskPage.waitFor(confirmButtonSelector);
+
+        const button = await metamaskPage.$(confirmButtonSelector);
+        await button.click()
+
+        await waitForUnlockedScreen(metamaskPage);
+      },
     }
   }
 }


### PR DESCRIPTION
Some dapps will need to ask to connect to MetaMask for privacy reasons

![Screen Shot 2019-05-16 at 1 42 09 PM](https://user-images.githubusercontent.com/9356633/57832242-5f327500-77e1-11e9-993e-f019b9fc4224.png)

This PR adds a method that approves the above request