### PR TITLE
chore: add a postinstall hook to fix npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "E2E testing for dApps using Puppeteer + MetaMask",
   "main": "index.js",
   "scripts": {
+    "postinstall": "rm -rf node_modules/**/.git",
     "test": "mocha test/test.js --timeout=200000 --exit"
   },
   "repository": {


### PR DESCRIPTION
When installing a new package, e.g. `npm install typescript` NPM show the following error:

```
➜  dappeteer git:(master) ✗ npm i typescript
npm ERR! path ~/decentraland/dappeteer/node_modules/websocket
npm ERR! code EISGIT
npm ERR! git ~/dappeteer/node_modules/websocket: Appears to be a git repo or submodule.
npm ERR! git     ~/dappeteer/node_modules/websocket
npm ERR! git Refusing to remove it. Update manually,
npm ERR! git or move it out of the way first.

npm ERR! A complete log of this run can be found in:
npm ERR!     ~/.npm/_logs/2019-06-03T14_24_57_253Z-debug.log
```

This is only a hack to temporary solve it, the real solution would be debug dependencies that have `.git` folders in the package and fix/replace them