### PR TITLE
[Test] Add tests for entire API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ node_modules
 test/server/data.js
 build
 dist
+yarn.lock
+.vscode/

--- a/test/server/index.html
+++ b/test/server/index.html
@@ -8,6 +8,8 @@
     <script src="web3.min.js"></script>
 </head>
 <body>
+    <button class="connect-button">Connect</button>
+    <button class="sign-button">Sign</button>
     <button class="increase-button">Increase</button>
     <script src="data.js"></script>
     <script src="main.js"></script>

--- a/test/server/main.js
+++ b/test/server/main.js
@@ -5,15 +5,29 @@ async function start() {
     const accounts = await web3.eth.getAccounts();
 
     const increaseButton = document.querySelector(".increase-button")
-    increaseButton.addEventListener('click', function () {
-        counterContract.methods.increase().send({
-            from: accounts[0]
-        }).then(res => {
-            console.log('success', res)
-        }).catch(err => {
-            console.log('fail', err)
-        })
-    })
+    increaseButton.addEventListener('click', async function () {
+        await counterContract.methods.increase().send({from: accounts[0]});
+        const txSent = document.createElement("div");
+        txSent.id = "txSent";
+        document.body.appendChild(txSent);
+    });
+
+    const connectButton = document.querySelector(".connect-button");
+    connectButton.addEventListener('click', async function () {
+        await ethereum.enable();
+        const connected = document.createElement("div");
+        connected.id = "connected";
+        document.body.appendChild(connected);
+    });
+
+    const signButton = document.querySelector(".sign-button");
+    signButton.addEventListener('click', async function () {
+        const accounts = await web3.eth.getAccounts();
+        await web3.eth.personal.sign("TEST", accounts[0]); 
+        const signed = document.createElement("div");
+        signed.id = "signed";
+        document.body.appendChild(signed);
+    });
 }
 
 start();

--- a/test/test.ts
+++ b/test/test.ts
@@ -31,7 +31,8 @@ before(async () => {
   browser = await dappeteer.launch(puppeteer)
   metamask = await dappeteer.getMetamask(browser, {
     // optional, else it will use a default seed
-    seed: 'pioneer casual canoe gorilla embrace width fiction bounce spy exhibit another dog'
+    seed: 'pioneer casual canoe gorilla embrace width fiction bounce spy exhibit another dog',
+    password: 'password1234'
   })
   testPage = await browser.newPage()
   await testPage.goto('localhost:8080')
@@ -60,6 +61,35 @@ describe('dappeteer', () => {
     await metamask.switchNetwork('localhost')
   })
 
+  it('should import private key', async () => {
+    await metamask.importPK('4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b10')
+  })
+
+  it('should switch accounts', async () => {
+    await metamask.switchAccount(1)
+  })
+
+  it('should lock and unlock', async () => {
+    await metamask.lock()
+    await metamask.unlock('password1234')
+  })
+
+  it("should connect to ethereum", async () => {
+    await clickElement(testPage, ".connect-button");
+    await metamask.approve();
+
+    // For some reason initial approve does not resolve nor fail promise
+    await clickElement(testPage, ".connect-button");
+    await testPage.waitForSelector("#connected");
+  });
+
+  it("should be able to sign", async () => {
+    await clickElement(testPage, ".sign-button");
+    await metamask.sign();
+
+    await testPage.waitForSelector("#signed");
+  });
+
   describe('test contract', async () => {
     let counterBefore
 
@@ -73,6 +103,7 @@ describe('dappeteer', () => {
 
       // submit tx
       await metamask.confirmTransaction()
+      await testPage.waitForSelector("#txSent");
     })
 
     it('should have increased count', async () => {


### PR DESCRIPTION
This PR adds tests for the following dappeteer functions:

- approve/sign
- lock/unlock
- import private key
- switch account

This covers all exposed functionality and thus will help when updating the bundled metamask extension (another PR I'm working on). Running the tests will make sure that all interactions still work successfully after an update. 

### Test Plan
```
npm test
```